### PR TITLE
fix yt-dlp issues again lol

### DIFF
--- a/.github/workflows/blank2.yml
+++ b/.github/workflows/blank2.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt install equivs libavutil-dev libavcodec-dev libswscale-dev python3-dev cython3 g++ nasm git libavfilter-dev libxmu-dev libxcb1-dev
         sudo apt install libfuse2 libdbus-1-dev libx11-dev libxinerama-dev libxrandr-dev yasm intltool autoconf libtool devscripts libass-dev libx264-dev
         sudo apt install libxss-dev libglib2.0-dev libpango1.0-dev libgtk-3-dev libxdg-basedir-dev libnotify-dev libc++-dev libplacebo-dev libx265-dev
-        sudo apt install ninja-build autotools-dev autoconf automake make build-essential pkg-config python3-pip desktop-file-utils zsync
+        sudo apt install ninja-build autotools-dev autoconf automake make build-essential pkg-config python3-pip desktop-file-utils zsync binutils
         sudo pip3 install packaging meson
         chmod a+x ./mpv-AppImage.sh && ./mpv-AppImage.sh
         mkdir dist

--- a/.github/workflows/blank2.yml
+++ b/.github/workflows/blank2.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -49,6 +49,9 @@ sed -i 's/export PYTHONHOME/#export PYTHONHOME/g' ./mpv.AppDir/AppRun
 # Likely go-appimage breaking something
 cp /lib64/ld-linux-x86-64.so.2 ./mpv.AppDir/lib64/ld-linux-x86-64.so.2 || exit 1
 
+# go appimage is not stripping the main binary
+strip --strip-unneeded ./mpv.AppDir/usr/bin/mpv || exit 1
+
 # maybe not needed but I had appimagetool bug out before if the AppDir isnt in the top level of home
 mv ./mpv.AppDir ../ && cd ../ || exit 1
 


### PR DESCRIPTION
Turns out it has to be built on ubuntu 24.04 for it to work. 

Also the mpv binary wasn't being stripped.