### PR TITLE
use ubuntu 24.04 to skip building vulkan headers

### DIFF
--- a/.github/workflows/blank2.yml
+++ b/.github/workflows/blank2.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt install equivs libavutil-dev libavcodec-dev libswscale-dev python3-dev cython3 g++ nasm git libavfilter-dev libxmu-dev libxcb1-dev
         sudo apt install libfuse2 libdbus-1-dev libx11-dev libxinerama-dev libxrandr-dev yasm intltool autoconf libtool devscripts libass-dev libx264-dev
         sudo apt install libxss-dev libglib2.0-dev libpango1.0-dev libgtk-3-dev libxdg-basedir-dev libnotify-dev libc++-dev libplacebo-dev libx265-dev
-        sudo apt install ninja-build autotools-dev autoconf automake make build-essential pkg-config python3-pip desktop-file-utils zsync
+        sudo apt install ninja-build autotools-dev autoconf automake make build-essential pkg-config python3-pip desktop-file-utils zsync binutils
         sudo pip3 install packaging meson
         chmod a+x ./mpv-AppImage.sh && ./mpv-AppImage.sh
         mkdir dist

--- a/.github/workflows/blank2.yml
+++ b/.github/workflows/blank2.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -49,6 +49,9 @@ sed -i 's/export PYTHONHOME/#export PYTHONHOME/g' ./mpv.AppDir/AppRun
 # Likely go-appimage breaking something
 cp /lib64/ld-linux-x86-64.so.2 ./mpv.AppDir/lib64/ld-linux-x86-64.so.2 || exit 1
 
+# go appimage is not stripping the main binary
+strip --strip-unneeded ./mpv.AppDir/usr/bin/mpv || exit 1
+
 # maybe not needed but I had appimagetool bug out before if the AppDir isnt in the top level of home
 mv ./mpv.AppDir ../ && cd ../ || exit 1
 

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -17,13 +17,6 @@ UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|mpv-AppImage|latest|*$ARCH.Ap
 rm -rf ./mpv 2>/dev/null
 mkdir -p ./mpv/mpv.AppDir && cd ./mpv/mpv.AppDir || exit 1
 
-# make vulkan headers
-wget "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.3.238.tar.gz"
-tar fx *tar* && cd Vulkan*
-cmake -S . -B build/
-sudo cmake --install build --prefix '/usr'
-cd .. && rm -rf ./*tar* ./Vulkan*
-
 # Build mpv
 if [ ! -d ./usr ]; then
 	CURRENTDIR="$(readlink -f "$(dirname "$0")")"


### PR DESCRIPTION
Turns out that even on 22.04 mpv requires newer vulkan headers.

Since everything is now bundled in the AppImage, I can build on new distros and this avoids the step of building the headers. 

