### PR TITLE
Automatically download yt-dlp if it is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Unofficial AppImage of mpv: https://github.com/mpv-player/mpv
 
+**This AppImage bundles everything and should work on any linux distro, even on musl based ones.** 
+
 It is possible that this appimage may fail to work with appimagelauncher, I recommend this alternative instead: https://github.com/ivan-hc/AM
 
 This appimage works without fuse2 as it can use fuse3 instead.

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -38,6 +38,9 @@ chmod +x ./go-appimagetool
 # disable this since we are not shipping python
 sed -i 's/export PYTHONHOME/#export PYTHONHOME/g' ./mpv.AppDir/AppRun
 
+# make AppRun source the yt-dlp hook
+sed -i '7i\. "$HERE"/yt-dlp_hook.sh' ./mpv.AppDir/AppRun
+
 # Fix some issue with yt-dlp not working
 # Likely go-appimage breaking something
 cp /lib64/ld-linux-x86-64.so.2 ./mpv.AppDir/lib64/ld-linux-x86-64.so.2 || exit 1

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -41,10 +41,6 @@ sed -i 's/export PYTHONHOME/#export PYTHONHOME/g' ./mpv.AppDir/AppRun
 # make AppRun source the yt-dlp hook
 sed -i '7i\. "$HERE"/yt-dlp_hook.sh' ./mpv.AppDir/AppRun
 
-# Fix some issue with yt-dlp not working
-# Likely go-appimage breaking something
-cp /lib64/ld-linux-x86-64.so.2 ./mpv.AppDir/lib64/ld-linux-x86-64.so.2 || exit 1
-
 # go appimage is not stripping the main binary
 strip --strip-unneeded ./mpv.AppDir/usr/bin/mpv || exit 1
 

--- a/mpv-AppImage.sh
+++ b/mpv-AppImage.sh
@@ -15,7 +15,7 @@ GOAPPIMAGETOOL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/rele
 APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
 UPINFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|mpv-AppImage|latest|*$ARCH.AppImage.zsync"
 rm -rf ./mpv 2>/dev/null
-mkdir -p ./mpv/mpv.AppDir && cd ./mpv/mpv.AppDir || exit 1
+mkdir -p ./mpv/mpv.AppDir && cp ./yt-dlp_hook.sh ./mpv/mpv.AppDir && cd ./mpv/mpv.AppDir || exit 1
 
 # Build mpv
 if [ ! -d ./usr ]; then

--- a/yt-dlp_hook.sh
+++ b/yt-dlp_hook.sh
@@ -11,7 +11,7 @@ if echo "$@" | grep -q "^http" && ! command -v yt-dlp >/dev/null 2>&1; then
 	if command -v wget >/dev/null 2>&1; then
 		wget -q "$YT" -O "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp
 	elif command -v curl >/dev/null 2>&1; then
-		curl -s "$YT" -o "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp
+		curl -Ls "$YT" -o "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp
 	else
 		echo "ERROR: You need wget or curl in order to download yt-dlp"
 	fi

--- a/yt-dlp_hook.sh
+++ b/yt-dlp_hook.sh
@@ -3,7 +3,7 @@
 # Download yt-dlp if needed
 CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 export PATH="$PATH:$CACHEDIR/mpv-appimage_yt-dlp"
-if echo "$@" | grep -q "^http" && ! command -v yt-dlp >/dev/null 2>&1; then
+if echo "$@" | grep -q "http" && ! command -v yt-dlp >/dev/null 2>&1; then
 	echo "Video link detected but yt-dlp is not installed, installing..."
 	mkdir -p "$CACHEDIR"/mpv-appimage_yt-dlp
 	YT=$(curl -Ls https://api.github.com/repos/yt-dlp/yt-dlp/releases \

--- a/yt-dlp_hook.sh
+++ b/yt-dlp_hook.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Download yt-dlp if needed
+CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+export PATH="$PATH:$CACHEDIR/mpv-appimage_yt-dlp"
+if echo "$@" | grep -q "^http" && ! command -v yt-dlp >/dev/null 2>&1; then
+	echo "Video link detected but yt-dlp is not installed, installing..."
+	mkdir -p "$CACHEDIR"/mpv-appimage_yt-dlp
+	YT=$(curl -Ls https://api.github.com/repos/yt-dlp/yt-dlp/releases \
+		| sed 's/[()",{} ]/\n/g' | grep -oi 'https.*yt.*linux$' | head -1)
+	if command -v wget >/dev/null 2>&1; then
+		wget -q "$YT" -O "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp
+	elif command -v curl >/dev/null 2>&1; then
+		curl -s "$YT" -o "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp
+	else
+		echo "ERROR: You need wget or curl in order to download yt-dlp"
+	fi
+fi
+
+chmod +x "$CACHEDIR"/mpv-appimage_yt-dlp/yt-dlp 2>/dev/null
+


### PR DESCRIPTION
Also noticed that when building in 24.04 the issues I had with yt-dlp not working are gone. 

So the re-copy of ld-linux.so is no longer needed. 