### PR TITLE
ffmpeg: enable image2 muxer

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -72,6 +72,7 @@ echo "--disable-muxers"        >> ./ffmpeg_options
 echo "--enable-muxer=mp4"      >> ./ffmpeg_options
 echo "--enable-muxer=matroska" >> ./ffmpeg_options
 echo "--enable-muxer=webm"     >> ./ffmpeg_options
+echo "--enable-muxer=image2"   >> ./ffmpeg_options
 echo "--disable-avdevice"      >> ./ffmpeg_options
 echo "-Dlibmpv=false"          >> ./mpv_options
 echo "-Dlibbluray=disabled"    >> ./mpv_options


### PR DESCRIPTION
## Problem

Commit 56c7612 ("debloat ffmpeg") added `--disable-muxers` and only re-enabled `mp4`, `matroska`, `webm`. The `image2` muxer was dropped.

This breaks **thumbfast** (po5/thumbfast), a widely-used mpv script: it spawns a subprocess with `--ovc=rawvideo --of=image2` to write seek-preview thumbnails. With this build, the spawned mpv exits with:

```
[encode] format not found
Encoding initialization failed.
Exiting... (Fatal error)
```

and the user sees `thumbfast: ERROR! cannot create mpv subprocess`, with no thumbnails on seek.

## Fix

Re-enable the `image2` muxer in `get-dependencies.sh`. `image2` is the single muxer that covers png/jpeg/bmp single-image output used by thumbfast and similar tools. Its size overhead is negligible (same muxer as always built before the debloat).

Tested locally: after the change, `mpv --of=image2` writes thumbnails correctly.