### PR TITLE
ffmpeg: enable rawvideo encoder for thumbfast

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -68,6 +68,7 @@ echo "--enable-version3"       >> ./ffmpeg_options
 echo "--disable-librsvg"       >> ./ffmpeg_options
 echo "--disable-programs"      >> ./ffmpeg_options
 echo "--disable-encoders"      >> ./ffmpeg_options
+echo "--enable-encoder=rawvideo" >> ./ffmpeg_options
 echo "--disable-muxers"        >> ./ffmpeg_options
 echo "--enable-muxer=mp4"      >> ./ffmpeg_options
 echo "--enable-muxer=matroska" >> ./ffmpeg_options


### PR DESCRIPTION
## Problem

thumbfast (po5/thumbfast) writes seek-preview thumbnails by spawning `mpv --ovc=rawvideo --of=image2`. PR #45 re-enabled the `image2` muxer, but the `rawvideo` **encoder** is still dropped by `--disable-encoders`, so the spawned subprocess still fails:

```
[encode] codec 'rawvideo' not found.
Error opening/initializing the selected video_out (--vo) device.
Exiting... (Interrupted by error)
```

Users no more see `thumbfast: ERROR! cannot create mpv subprocess` error, but they see gray thumbnails.

## Fix

Re-enable the `rawvideo` encoder in `get-dependencies.sh`. It is a trivial encoder (stores raw video bytes) with negligible size cost, and was always built before the debloat.

Verified locally with the v0.41.0 build: with both #45 and this change, `mpv --ovc=rawvideo --of=image2` produces correct thumbnail frames.